### PR TITLE
Remove lib prefix when building with msvc on Windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,6 @@ if(MSVC)
 	target_compile_options(libpotassco PRIVATE "/W4" )
 	set(VC_RELEASE_OPTIONS /Oi /Oy /GL /Gy)
 	target_compile_options(libpotassco PUBLIC "$<$<CONFIG:RELEASE>:${VC_RELEASE_OPTIONS}>")
-	set_target_properties(libpotassco PROPERTIES PREFIX "lib")
 endif()
 target_include_directories(libpotassco PUBLIC
 	$<BUILD_INTERFACE:${LIB_POTASSCO_SOURCE_DIR}>


### PR DESCRIPTION
I think the original idea was to have the same library names on Windows and *nix. That's why the build script manually adds "lib" to the library name when building with msvc. It turns out that this convention introduces more special cases in build scripts that are to work across platforms. With build tools on *nix we do not have to mention the "lib" prefix because it is not just a convention but required. On Windows we have to use the lib prefix because the full filename (without extension) has to be given.

This is why I am suggesting to remove the "lib" prefix on Windows. It should not cause too much trouble because most people won't use the library and as long as cmake is used things will happen behind the scenes. Again this is motivated by a concrete use case that can be simplified with this change. Since this can cause breakage it is up to you to decline the request.