### PR TITLE
libpotassco: add PPC case to string_convert.cpp

### DIFF
--- a/src/string_convert.cpp
+++ b/src/string_convert.cpp
@@ -25,6 +25,9 @@
 #include <cerrno>
 #include <cstdio>
 #include <algorithm>
+#if defined(__APPLE__) && defined(__POWERPC__)
+#include <xlocale.h>
+#endif
 #if defined(_MSC_VER)
 #pragma warning (disable : 4996)
 #define strtod_l   _strtod_l


### PR DESCRIPTION
Darwin PPC needs to be added, otherwise the build fails on locale-related stuff and `strtod_l`.