### PR TITLE
add ci tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+name: CI tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    name: libpotassco tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        include:
+          - os: 'ubuntu-latest'
+            generator: 'Ninja'
+            build_type: 'Debug'
+          - os: 'macos-latest'
+            generator: 'Ninja'
+            build_type: 'Debug'
+          - os: 'windows-latest'
+            generator: 'Visual Studio 17 2022'
+            build_type: 'Debug'
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: install prerequisites on ubuntu
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run:
+        sudo apt install ninja-build
+
+    - name: install prerequisites on macos
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew update
+        brew install ninja
+
+    - name: Configure CMake
+      run: >
+        cmake
+        -G "${{ matrix.generator }}"
+        -B "${{github.workspace}}/build"
+        -DCMAKE_BUILD_TYPE="${{matrix.build_type}}"
+        -DLIB_POTASSCO_BUILD_TESTS="On"
+        -DCMAKE_CXX_STANDARD="14"
+
+    - name: Build
+      run: >
+        cmake
+        --build "${{github.workspace}}/build"
+        --config "${{matrix.build_type}}"
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: >
+        ctest
+        -C "${{matrix.build_type}}"


### PR DESCRIPTION
This PR adds CI tests for libpotassco running on linux, macos, and windows using the default compilers. Note that I had to enable C++14 support to compile on macos. The `unordered_map` include fails without adding it.