### PR TITLE
add support for building on haiku

### DIFF
--- a/src/string_convert.cpp
+++ b/src/string_convert.cpp
@@ -38,7 +38,7 @@ inline my_locale_t default_locale() { return _create_locale(LC_ALL, "C"); }
 inline unsigned long long strtoull(const char* str, char** endptr, int base) { return  _strtoui64(str, endptr, base); }
 inline long long strtoll(const char* str, char** endptr, int base) { return  _strtoi64(str, endptr, base); }
 #endif
-#elif defined(__CYGWIN__) || defined (__MINGW32__) || defined (__OpenBSD__)
+#elif defined(__CYGWIN__) || defined (__MINGW32__) || defined (__OpenBSD__) || defined(__HAIKU__)
 #include <locale>
 typedef std::locale my_locale_t;
 static double strtod_l(const char* x, char** end, const my_locale_t& loc) {


### PR DESCRIPTION
the change set fixes a compile error that occurs when trying to compile on haiku..

example build without changeset below:

```
src/string_convert.cpp:233:15: error: 'strtod_l' was not declared in this scope; did you mean 'strtoull'?
  233 |         out = strtod_l(x, &err, default_locale_g.loc_);
      |               ^~~~~~~~
      |               strtoull
src/CMakeFiles/libpotassco.dir/build.make:201: recipe for target 'src/CMakeFiles/libpotassco.dir/string_convert.cpp.o' failed
make[2]: *** [src/CMakeFiles/libpotassco.dir/string_convert.cpp.o] Error 1
CMakeFiles/Makefile2:115: recipe for target 'src/CMakeFiles/libpotassco.dir/all' failed
make[1]: *** [src/CMakeFiles/libpotassco.dir/all] Error 2
Makefile:135: recipe for target 'all' failed
make: *** [all] Error 2
```