### PR TITLE
Reifier integration

### DIFF
--- a/app/lpconvert.cpp
+++ b/app/lpconvert.cpp
@@ -27,6 +27,7 @@
 #include <potassco/aspif_text.h>
 #include <potassco/convert.h>
 #include <potassco/error.h>
+#include <potassco/reify.h>
 #include <potassco/smodels.h>
 
 #include <potassco/program_opts/errors.h>
@@ -83,18 +84,20 @@ public:
         fail(EXIT_FAILURE, error, info);
     }
 
-    enum class Format : unsigned { auto_, text, smodels, aspif_v1, aspif };
+    enum class Format : uint8_t { auto_, text, smodels, aspif_v1, aspif, reify };
 
 private:
-    std::string input_;
-    std::string output_;
-    std::string pred_;
-    Format      format_{Format::auto_};
-    bool        potassco_ = false;
-    bool        filter_   = false;
+    std::string                input_;
+    std::string                output_;
+    std::string                pred_;
+    Format                     format_{Format::auto_};
+    Potassco::Reifier::Options reifyOpts_;
+    bool                       potassco_ = false;
+    bool                       filter_   = false;
 };
+
 POTASSCO_SET_ENUM_ENTRIES(LpConvert::Format, {auto_, "auto"sv}, {text, "text"sv}, {smodels, "smodels"sv},
-                          {aspif_v1, "aspif-v1"sv}, {aspif, "aspif"sv});
+                          {aspif_v1, "aspif-v1"sv}, {aspif, "aspif"sv}, {reify, "reify"sv});
 
 void LpConvert::initOptions(OptionContext& root) {
     OptionGroup convert("Conversion Options");
@@ -103,9 +106,12 @@ void LpConvert::initOptions(OptionContext& root) {
         ("-p,potassco", flag(potassco_, false), "Enable potassco extensions")                                    //
         ("-f,filter", flag(filter_, false), "Hide converted potassco predicates")                                //
         ("-o,output", storeTo(output_, std::string()).arg("<file>"), "Write output to <file> (default: stdout)") //
-        ("format", storeTo(format_, Format::auto_), "Output format (text|smodels|aspif|aspif-v1)")               //
+        ("format", storeTo(format_, Format::auto_), "Output format (text|smodels|aspif|aspif-v1|reify)")         //
         ("-t,text", flag([this](bool) { format_ = Format::text; }), "Convert to ground text format")             //
+        ("-r,reify", flag([this](bool) { format_ = Format::reify; }), "Convert program to reified facts")        //
         ("aux-pred", storeTo(pred_, std::string()), "Prefix/Predicate for atom numbers in text output")          //
+        ("reify-sccs", flag(reifyOpts_.calculateSccs, false), "Calculate SCCs for reified output")               //
+        ("reify-steps", flag(reifyOpts_.reifyStep, false), "Add step numbers to reified output")                 //
         ;
     root.add(std::move(convert));
 }
@@ -160,6 +166,7 @@ void LpConvert::run() try {
         case Format::aspif_v1: out1 = std::make_unique<Potassco::AspifOutput>(os, 1); break;
         case Format::auto_   : [[fallthrough]];
         case Format::aspif   : out1 = std::make_unique<Potassco::AspifOutput>(os, 2); break;
+        case Format::reify   : out1 = std::make_unique<Potassco::Reifier>(os, reifyOpts_); break;
     }
     in.peek() == 'a' ? Potassco::readAspif(in, *out1) : Potassco::readSmodels(in, *out1, opts);
 }

--- a/potassco/graph.h
+++ b/potassco/graph.h
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2017 - 2025, Roland Kaminski
+// Copyright (c) 2025 - present, Francois Laferriere
+//
+// This file is part of Potassco.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace Potassco {
+/////////////////////////////////////////////////////////////////////////////////////////
+// Graph template
+/////////////////////////////////////////////////////////////////////////////////////////
+template <std::integral DataType = uintptr_t, std::unsigned_integral IdType = uint32_t>
+class Graph {
+public:
+    Graph() = default;
+    auto addNode(DataType data) -> IdType {
+        auto id = static_cast<IdType>(nodes_.size());
+        nodes_.emplace_back(data, open_);
+        return id;
+    }
+    auto addEdge(IdType from, IdType to) -> void { nodes_.at(from).edges.push_back(to); }
+    void clear() { nodes_.clear(); }
+
+    using Scc    = std::vector<DataType>;
+    using SccVec = std::vector<Scc>;
+    /*!
+     * \brief Compute strongly connected components (SCCs) using Tarjan's algorithm.
+     *
+     * \param skipTrivial If true, SCCs of size 1 are omitted from the returned vector.
+     *
+     * \note This function modifies the internal state of the graph (node visit markers and traversal offsets).
+     *       Node IDs and edges remain unchanged.
+     */
+    auto computeSccs(bool skipTrivial = false) -> SccVec {
+        using IdVec = std::vector<IdType>;
+        SccVec     sccs;
+        IdVec      stack;
+        IdVec      trail;
+        const auto open   = open_;      // open state, i.e. node not yet seen
+        const auto closed = 1u - open_; // closed state, i.e. node has its scc determined
+        for (auto xId = IdType(0); auto& x : nodes_) {
+            if (x.min == open) {
+                auto index = IdType(1);
+                auto push  = [&](IdType nId, Node& n) {
+                    n.min = ++index;
+                    n.off = 0u;
+                    stack.emplace_back(nId);
+                    trail.emplace_back(nId);
+                };
+                push(xId, x);
+
+                while (not stack.empty()) {
+                    auto  yId      = stack.back();
+                    auto& y        = nodes_[yId];
+                    auto  finished = true;
+                    for (auto zId : std::span(y.edges).subspan(y.off)) {
+                        ++y.off;
+                        if (auto& z = nodes_.at(zId); z.min == open) {
+                            push(zId, z);
+                            finished = false;
+                            break;
+                        }
+                    }
+                    if (finished) {
+                        stack.pop_back();
+                        bool root = true;
+                        for (auto zId : y.edges) {
+                            if (auto& z = nodes_[zId]; z.min != closed && z.min < y.min) {
+                                assert(z.min != open && "stack invariant broken");
+                                root  = false;
+                                y.min = z.min;
+                            }
+                        }
+
+                        if (root) {
+                            Scc  scc;
+                            auto nId = xId;
+                            do {
+                                nId = trail.back();
+                                trail.pop_back();
+                                auto& n = nodes_[nId];
+                                n.min   = closed;
+                                scc.emplace_back(n.data);
+                            } while (nId != yId);
+
+                            if (not skipTrivial || scc.size() > 1) {
+                                sccs.push_back(std::move(scc));
+                            }
+                        }
+                    }
+                }
+            }
+            ++xId;
+        }
+        open_ = closed;
+        return sccs;
+    }
+    //! Compute only SCCs of size > 1 (non-trivial).
+    auto computeNonTrivialSccs() -> SccVec { return computeSccs(true); }
+
+private:
+    struct Node {
+        Node(DataType d, IdType m) : data(d), min(m), off(0) {}
+        std::vector<IdType> edges;
+        DataType            data{0};
+        IdType              min{0};
+        IdType              off{0};
+    };
+
+    std::vector<Node> nodes_;
+    IdType            open_ = 0; // current "unseen" state - either 0 or 1
+};
+} // namespace Potassco

--- a/potassco/reify.h
+++ b/potassco/reify.h
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2017 - 2025, Roland Kaminski
+// Copyright (c) 2025 - present, Francois Laferriere
+//
+// This file is part of Potassco.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#pragma once
+
+#include <potassco/aspif.h>
+
+#include <cstdint>
+
+namespace Potassco {
+//! Writes a program in reified facts format to the given output stream.
+/*!
+ * \ingroup WriteType
+ */
+class Reifier : public Potassco::AbstractProgram {
+public:
+    //! Options for configuring Reifier behavior.
+    struct Options {
+        bool calculateSccs = false; //!< Compute strongly connected components.
+        bool reifyStep     = false; //!< Include step information in output.
+    };
+    //! Creates a new object and associates it with the given output stream.
+    /*!
+     * \param out Output stream to which program is written.
+     * \param opts Options to configure Reifier behavior.
+     */
+    explicit Reifier(std::ostream& out, const Options& opts);
+    ~Reifier() noexcept override;
+    Reifier(const Reifier&)            = delete;
+    Reifier& operator=(const Reifier&) = delete;
+
+    //! Parses an aspif program and writes facts to the output stream.
+    void parse(std::istream& in);
+
+    //! Writes the program header (e.g., incremental tag) as facts.
+    void initProgram(bool incremental) override;
+    //! Prepares for a new program step (currently does nothing).
+    void beginStep() override;
+    //! Writes a rule as facts
+    void rule(HeadType ht, AtomSpan head, LitSpan body) override;
+    //! Writes a rule as facts
+    void rule(HeadType ht, AtomSpan head, Weight_t bound, WeightLitSpan body) override;
+    //! Writes a minimize directive as facts.
+    void minimize(Weight_t prio, WeightLitSpan lits) override;
+    //! Writes a projection directive as facts.
+    void project(AtomSpan atoms) override;
+    //! Writes an output atom directive as facts.
+    void outputAtom(Atom_t atom, std::string_view name) override;
+    //! Writes an output term directive as facts.
+    void outputTerm(Id_t termId, std::string_view name) override;
+    //! Writes an output condition as facts.
+    void output(Id_t termId, LitSpan condition) override;
+    //! Writes an external directive as facts.
+    void external(Atom_t a, TruthValue v) override;
+    //! Writes assumption directive as facts.
+    void assume(LitSpan lits) override;
+    //! Writes a heuristic directive as facts.
+    void heuristic(Atom_t a, DomModifier t, int bias, unsigned prio, LitSpan condition) override;
+    //! Writes an edge directive as facts.
+    void acycEdge(int s, int t, LitSpan condition) override;
+    //! Writes a theory number term as facts.
+    void theoryTerm(Id_t termId, int number) override;
+    //! Writes a theory symbolic term as facts.
+    void theoryTerm(Id_t termId, std::string_view name) override;
+    //! Writes a theory compound term as facts.
+    void theoryTerm(Id_t termId, int cId, IdSpan args) override;
+    //! Writes a theory element as facts.
+    void theoryElement(Id_t elementId, IdSpan terms, LitSpan cond) override;
+    //! Writes a theory atom as facts.
+    void theoryAtom(Id_t atomOrZero, Id_t termId, IdSpan elements) override;
+    //! Writes a theory atom with guard as facts.
+    void theoryAtom(Id_t atomOrZero, Id_t termId, IdSpan elements, Id_t op, Id_t rhs) override;
+
+    //! At the end of each step, writes SCC facts and clears stepData_.
+    void endStep() override;
+
+private:
+    //! Stores step-specific tuples and graph nodes.
+    struct StepData;
+    using StepDataPtr = std::unique_ptr<StepData>;
+    //! Compute SCCs for a given head and body literals.
+    template <typename L>
+    void calculateSccs(AtomSpan head, std::span<const L> body);
+    //! Print a fact to the output stream.
+    template <typename... T>
+    void printFact(const char* name, const T&... args);
+    //! Print a fact for the current step if step reification is enabled.
+    template <typename... T>
+    void printStepFact(const char* name, const T&... args);
+    //! Insert a tuple into a map and print a fact if it was not already present.
+    template <typename M, typename T>
+    auto tuple(M& map, const char* name, std::span<T> args) -> size_t;
+    //! Insert a theory tuple and return its ID.
+    auto theoryTuple(IdSpan args) -> size_t;
+    //! Insert a literal tuple and return its ID.
+    auto litTuple(LitSpan args) -> size_t;
+    //! Insert an atom tuple and return its ID.
+    auto atomTuple(AtomSpan args) -> size_t;
+    //! Insert a theory element tuple and return its ID.
+    auto theoryElementTuple(IdSpan args) -> size_t;
+    //! Insert a weighted literal tuple and return its ID.
+    auto weightLitTuple(WeightLitSpan args) -> size_t;
+    //! Add a node for the given atom to the graph.
+    auto addNode(Atom_t atom) -> uint32_t;
+
+    std::ostream& out_;
+    StepDataPtr   stepData_;
+    size_t        step_ = 0;
+    bool          calculateSccs_;
+    bool          reifyStep_;
+};
+
+} // namespace Potassco

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,8 +19,10 @@ set(header
     ${header_path}/enum.h
     ${header_path}/error.h
     ${header_path}/format.h
+    ${header_path}/graph.h
     ${header_path}/match_basic_types.h
     ${header_path}/platform.h
+    ${header_path}/reify.h
     ${header_path}/rule_utils.h
     ${header_path}/smodels.h
     ${header_path}/theory_data.h)
@@ -36,6 +38,7 @@ set(src
     error.cpp
     match_basic_types.cpp
     program_options.cpp
+    reify.cpp
     rule_utils.cpp
     smodels.cpp
     string_convert.cpp

--- a/src/reify.cpp
+++ b/src/reify.cpp
@@ -1,0 +1,323 @@
+//
+// Copyright (c) 2017 - 2025, Roland Kaminski
+// Copyright (c) 2025 - present, Francois Laferriere
+//
+// This file is part of Potassco.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#include <potassco/enum.h>
+#include <potassco/error.h>
+#include <potassco/graph.h>
+#include <potassco/reify.h>
+
+#include <algorithm>
+#include <ostream>
+#include <ranges>
+#include <unordered_map>
+#include <vector>
+
+namespace Potassco {
+namespace {
+/////////////////////////////////////////////////////////////////////////////////////////
+// Helpers
+/////////////////////////////////////////////////////////////////////////////////////////
+struct Head {
+    HeadType type;
+    size_t   id;
+};
+
+struct Normal {
+    size_t id;
+};
+
+struct Sum {
+    size_t   id;
+    Weight_t bound;
+};
+
+struct Quoted {
+    std::string_view str;
+};
+
+template <typename T>
+void printValue(std::ostream& out, const T& value) {
+    out << value;
+}
+
+void printValue(std::ostream& out, const WeightLit& value) {
+    printValue(out, value.lit);
+    out << ",";
+    printValue(out, value.weight);
+}
+
+void printValue(std::ostream& out, const Head& h) {
+    const char* name = (h.type == HeadType::disjunctive ? "disjunction" : "choice");
+    out << name << "(" << h.id << ")";
+}
+
+void printValue(std::ostream& out, const Normal& n) { out << "normal(" << n.id << ")"; }
+
+void printValue(std::ostream& out, const Sum& s) { out << "sum(" << s.id << "," << s.bound << ")"; }
+
+void printValue(std::ostream& out, const Quoted& q) {
+    out.put('"');
+    for (auto c : q.str) {
+        switch (c) {
+            case '\n': out << "\\n"; break;
+            case '\\': out << "\\\\"; break;
+            case '"' : out << "\\\""; break;
+            default  : out.put(c); break;
+        }
+    }
+    out.put('"');
+}
+
+template <typename T, typename... V>
+void printCommaSeparated(std::ostream& out, const T& t, const V&... v) {
+    printValue(out, t);
+    ((out << ",", printValue(out, v)), ...);
+}
+template <typename T>
+struct VectorHash {
+    size_t operator()(const std::vector<T>& vec) const {
+        static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+        auto* data = reinterpret_cast<const char*>(vec.data());
+        return std::hash<std::string_view>{}({data, vec.size() * sizeof(T)});
+    }
+};
+
+template <typename T>
+std::vector<T> toVec(std::span<const T> span) {
+    return {span.begin(), span.end()};
+}
+
+} // end unnamed namespace
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// Reifier
+/////////////////////////////////////////////////////////////////////////////////////////
+template <typename T>
+using SeqMap = std::unordered_map<std::vector<T>, size_t, VectorHash<T>>;
+
+struct Reifier::StepData {
+    SeqMap<Id_t>      theoryTuples;
+    SeqMap<Id_t>      theoryElementTuples;
+    SeqMap<Lit_t>     litTuples;
+    SeqMap<Atom_t>    atomTuples;
+    SeqMap<WeightLit> weightLitTuples;
+
+    Graph<Atom_t>                        graph;
+    std::unordered_map<Atom_t, uint32_t> nodes;
+
+    void clear() {
+        theoryTuples.clear();
+        theoryElementTuples.clear();
+        litTuples.clear();
+        atomTuples.clear();
+        weightLitTuples.clear();
+        graph.clear();
+        nodes.clear();
+    }
+};
+
+Reifier::Reifier(std::ostream& out, const Options& opts)
+    : out_(out)
+    , stepData_(std::make_unique<StepData>())
+    , calculateSccs_(opts.calculateSccs)
+    , reifyStep_(opts.reifyStep) {}
+
+Reifier::~Reifier() noexcept = default;
+
+template <typename... T>
+void Reifier::printFact(const char* name, const T&... args) {
+    out_ << name << "(";
+    printCommaSeparated(out_, args...);
+    out_ << ").\n";
+}
+
+template <typename... T>
+void Reifier::printStepFact(const char* name, const T&... args) {
+    if (reifyStep_) {
+        printFact(name, args..., step_);
+    }
+    else {
+        printFact(name, args...);
+    }
+}
+
+template <typename M, typename T>
+auto Reifier::tuple(M& map, const char* name, std::span<T> args) -> size_t {
+    auto owned = toVec(args);
+    std::ranges::sort(owned);
+    owned.erase(std::ranges::unique(owned).begin(), owned.end());
+    auto [it, isNew] = map.emplace(std::move(owned), map.size());
+    if (isNew) {
+        printStepFact(name, it->second);
+        for (const auto& x : it->first) { printStepFact(name, it->second, x); }
+    }
+    return it->second;
+}
+
+auto Reifier::theoryTuple(IdSpan args) -> size_t {
+    auto& map        = stepData_->theoryTuples;
+    auto  owned      = toVec(args);
+    auto [it, isNew] = map.emplace(std::move(owned), map.size());
+    if (isNew) {
+        printStepFact("theory_tuple", it->second);
+        int arg = 0;
+        for (const auto& x : it->first) {
+            printStepFact("theory_tuple", it->second, arg, x);
+            ++arg;
+        }
+    }
+    return it->second;
+}
+
+auto Reifier::theoryElementTuple(IdSpan args) -> size_t {
+    return tuple(stepData_->theoryElementTuples, "theory_element_tuple", args);
+}
+
+auto Reifier::litTuple(LitSpan args) -> size_t { return tuple(stepData_->litTuples, "literal_tuple", args); }
+
+auto Reifier::weightLitTuple(WeightLitSpan args) -> size_t {
+    return tuple(stepData_->weightLitTuples, "weighted_literal_tuple", args);
+}
+
+auto Reifier::atomTuple(AtomSpan args) -> size_t { return tuple(stepData_->atomTuples, "atom_tuple", args); }
+
+auto Reifier::addNode(Atom_t atom) -> uint32_t {
+    auto [it, isNew] = stepData_->nodes.try_emplace(atom, 0);
+    if (isNew) {
+        it->second = stepData_->graph.addNode(atom);
+    }
+    return it->second;
+}
+
+void Reifier::initProgram(bool incremental) {
+    if (incremental) {
+        printFact("tag", "incremental");
+    }
+}
+
+void Reifier::beginStep() {}
+
+void Reifier::rule(HeadType ht, AtomSpan head, LitSpan body) {
+    auto headId = atomTuple(head);
+    auto bodyId = litTuple(body);
+    printStepFact("rule", Head{ht, headId}, Normal{bodyId});
+    if (calculateSccs_) {
+        calculateSccs(head, body);
+    }
+}
+
+void Reifier::rule(HeadType ht, AtomSpan head, Weight_t bound, WeightLitSpan body) {
+    auto headId = atomTuple(head);
+    auto bodyId = weightLitTuple(body);
+    printStepFact("rule", Head{ht, headId}, Sum{bodyId, bound});
+    if (calculateSccs_) {
+        calculateSccs(head, body);
+    }
+}
+
+template <typename L>
+void Reifier::calculateSccs(AtomSpan head, std::span<const L> body) {
+    for (const auto& atom : head) {
+        auto uId = addNode(atom);
+        for (const auto& elem : body) {
+            if (lit(elem) > 0) {
+                auto vId = addNode(Potassco::atom(elem));
+                stepData_->graph.addEdge(uId, vId);
+            }
+        }
+    }
+}
+
+void Reifier::minimize(Weight_t prio, WeightLitSpan lits) { printStepFact("minimize", prio, weightLitTuple(lits)); }
+
+void Reifier::project(AtomSpan atoms) {
+    for (const auto& x : atoms) { printStepFact("project", x); }
+}
+
+void Reifier::outputAtom(Atom_t atom, std::string_view name) { printStepFact("outputAtom", name, atom); }
+
+void Reifier::outputTerm(Id_t termId, std::string_view name) { printStepFact("outputTerm", name, termId); }
+
+void Reifier::output(Id_t termId, LitSpan condition) { printStepFact("output", termId, litTuple(condition)); }
+
+void Reifier::external(Atom_t a, TruthValue v) { printStepFact("external", a, enum_name(v)); }
+
+void Reifier::assume(LitSpan lits) {
+    for (const auto& x : lits) { printStepFact("assume", x); }
+}
+
+void Reifier::heuristic(Atom_t a, DomModifier t, int bias, unsigned prio, LitSpan condition) {
+    printStepFact("heuristic", a, enum_name(t), bias, prio, litTuple(condition));
+}
+
+void Reifier::acycEdge(int s, int t, LitSpan condition) { printStepFact("edge", s, t, litTuple(condition)); }
+
+void Reifier::theoryTerm(Id_t termId, int number) { printStepFact("theory_number", termId, number); }
+
+void Reifier::theoryTerm(Id_t termId, std::string_view name) { printStepFact("theory_string", termId, Quoted{name}); }
+
+void Reifier::theoryTerm(Id_t termId, int cId, IdSpan args) {
+    if (cId >= 0) {
+        printStepFact("theory_function", termId, cId, theoryTuple(args));
+    }
+    else {
+        const char* type = "";
+        switch (cId) {
+            case -1: type = "tuple"; break;
+            case -2: type = "set"; break;
+            case -3: type = "list"; break;
+            default: POTASSCO_ASSERT_NOT_REACHED("unexpected tuple type");
+        }
+        printStepFact("theory_sequence", termId, type, theoryTuple(args));
+    }
+}
+
+void Reifier::theoryElement(Id_t elementId, IdSpan terms, LitSpan cond) {
+    auto tt = theoryTuple(terms);
+    auto lt = litTuple(cond);
+    printStepFact("theory_element", elementId, tt, lt);
+}
+
+void Reifier::theoryAtom(Id_t atomOrZero, Id_t termId, IdSpan elements) {
+    printStepFact("theory_atom", atomOrZero, termId, theoryElementTuple(elements));
+}
+
+void Reifier::theoryAtom(Id_t atomOrZero, Id_t termId, IdSpan elements, Id_t op, Id_t rhs) {
+    printStepFact("theory_atom", atomOrZero, termId, theoryElementTuple(elements), op, rhs);
+}
+
+void Reifier::endStep() {
+    for (size_t i = 0; const auto& scc : stepData_->graph.computeNonTrivialSccs()) {
+        for (auto x : std::views::reverse(scc)) { printStepFact("scc", i, x); }
+        ++i;
+    }
+    if (reifyStep_) {
+        stepData_->clear();
+        ++step_;
+    }
+}
+
+void Reifier::parse(std::istream& in) { readAspif(in, *this); }
+
+} // namespace Potassco

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable(test_potassco_lp)
 target_sources(test_potassco_lp PRIVATE
     test_aspif.cpp
     test_error.cpp
+    test_graph.cpp
+    test_reify.cpp
     test_smodels.cpp
     test_text.cpp)
 add_executable(test_potassco_opts)

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -1,0 +1,151 @@
+//
+// Copyright (c) 2025 - present, Francois Laferriere
+//
+// This file is part of Potassco.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#include <potassco/graph.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sstream>
+
+namespace Potassco::Test::Graph {
+
+namespace {
+struct Fixture {
+    std::string toString(const Potassco::Graph<uint32_t>::SccVec& sccs) {
+        std::ostringstream out;
+        out << "[";
+        std::string_view sccVecSeparator;
+        for (const auto& scc : sccs) {
+            out << sccVecSeparator << "[";
+            std::string_view sccSeparator;
+            for (auto id : scc) {
+                out << sccSeparator << static_cast<char>('a' + id);
+                sccSeparator = ",";
+            }
+            out << "]";
+            sccVecSeparator = ",";
+        }
+        out << "]";
+        return out.str();
+    }
+
+    Potassco::Graph<uint32_t> g;
+};
+} // end unnamed namespace
+
+TEST_CASE_METHOD(Fixture, "Graph empty", "[reify][graph]") {
+    REQUIRE(g.computeSccs().empty());
+}
+
+TEST_CASE_METHOD(Fixture, "Graph single node", "[reify][graph]") {
+    g.addNode(0);
+    auto sccs = g.computeSccs();
+    REQUIRE(sccs.size() == 1);
+    REQUIRE(toString(sccs) == "[[a]]");
+}
+
+TEST_CASE_METHOD(Fixture, "Graph acyclic", "[reify][graph]") {
+    auto idA = g.addNode(0);
+    auto idB = g.addNode(1);
+    auto idC = g.addNode(2);
+
+    g.addEdge(idA, idB);
+    g.addEdge(idB, idC);
+
+    auto sccs = g.computeSccs();
+    REQUIRE(sccs.size() == 3);
+    REQUIRE(toString(sccs) == "[[c],[b],[a]]");
+    REQUIRE(g.computeNonTrivialSccs().empty());
+}
+
+TEST_CASE_METHOD(Fixture, "Graph single cycle", "[reify][graph]") {
+    auto idA = g.addNode(0);
+    auto idB = g.addNode(1);
+    auto idC = g.addNode(2);
+    g.addNode(3);
+
+    g.addEdge(idA, idB);
+    g.addEdge(idB, idC);
+    g.addEdge(idC, idA);
+
+    auto sccs = g.computeSccs();
+    REQUIRE(sccs.size() == 2);
+    REQUIRE(toString(sccs) == "[[c,b,a],[d]]");
+}
+
+TEST_CASE_METHOD(Fixture, "Graph multiple cycles", "[reify][graph]") {
+    auto idA = g.addNode(0);
+    auto idB = g.addNode(1);
+    auto idC = g.addNode(2);
+    auto idD = g.addNode(3);
+    auto idE = g.addNode(4);
+    auto idF = g.addNode(5);
+    auto idG = g.addNode(6);
+    auto idH = g.addNode(7);
+    auto idI = g.addNode(8);
+
+    g.addEdge(idA, idG);
+    g.addEdge(idB, idE);
+    g.addEdge(idB, idH);
+    g.addEdge(idC, idI);
+    g.addEdge(idC, idH);
+    g.addEdge(idD, idF);
+    g.addEdge(idE, idA);
+    g.addEdge(idF, idB);
+    g.addEdge(idF, idC);
+    g.addEdge(idG, idD);
+
+    REQUIRE(toString(g.computeSccs()) == "[[h],[i],[c],[e,b,f,d,g,a]]");
+}
+
+TEST_CASE_METHOD(Fixture, "Graph preserved", "[reify][graph]") {
+    auto idA = g.addNode(0);
+    auto idB = g.addNode(1);
+    auto idC = g.addNode(2);
+    auto idD = g.addNode(3);
+    auto idE = g.addNode(4);
+    auto idF = g.addNode(5);
+    auto idG = g.addNode(6);
+    auto idH = g.addNode(7);
+    auto idI = g.addNode(8);
+
+    g.addEdge(idA, idB);
+    g.addEdge(idB, idC);
+    g.addEdge(idC, idH);
+    g.addEdge(idC, idD);
+    g.addEdge(idD, idE);
+    g.addEdge(idE, idF);
+    g.addEdge(idE, idB);
+    g.addEdge(idE, idC);
+    g.addEdge(idF, idG);
+    g.addEdge(idG, idF);
+    g.addEdge(idH, idI);
+    g.addEdge(idI, idH);
+
+    const auto expected = "[[i,h],[g,f],[e,d,c,b],[a]]";
+    REQUIRE(toString(g.computeSccs()) == expected);
+    REQUIRE(toString(g.computeSccs()) == expected);
+    REQUIRE(toString(g.computeSccs()) == expected);
+}
+
+} // namespace Potassco::Test::Graph

--- a/tests/test_reify.cpp
+++ b/tests/test_reify.cpp
@@ -1,0 +1,236 @@
+//
+// Copyright (c) 2017 - 2025, Roland Kaminski
+// Copyright (c) 2025 - present, Francois Laferriere
+//
+// This file is part of Potassco.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+#include <potassco/aspif_text.h>
+#include <potassco/reify.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sstream>
+
+namespace Potassco::Test::Reify {
+
+namespace {
+struct Fixture {
+    bool readText(bool scc = false, bool step = false) {
+        Reifier        prg(out, {scc, step});
+        AspifTextInput parser(&prg);
+        return readProgram(in, parser) == 0;
+    }
+
+    bool readAspif(bool scc = false, bool step = false) {
+        Reifier    prg(out, {scc, step});
+        AspifInput parser(prg);
+        return readProgram(in, parser) == 0;
+    }
+
+    std::stringstream in;
+    std::stringstream out;
+};
+} // end unnamed namespace
+
+TEST_CASE_METHOD(Fixture, "Reify empty", "[reify]") {
+    REQUIRE(readText());
+    REQUIRE(out.str() == "");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify incremental", "[reify]") {
+    in << "#incremental.";
+    REQUIRE(readText());
+    REQUIRE(out.view() == "tag(incremental).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify normal", "[reify]") {
+    in << "a:-b.";
+    REQUIRE(readText());
+    REQUIRE(
+        out.str() ==
+        "atom_tuple(0).\natom_tuple(0,1).\nliteral_tuple(0).\nliteral_tuple(0,2).\nrule(disjunction(0),normal(0)).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify step", "[reify]") {
+    in << "#incremental.";
+    in << "a:-b.";
+    in << "#step.";
+    in << "c:-b.";
+
+    const auto expected = "tag(incremental).\n"
+                          "atom_tuple(0,0).\n"
+                          "atom_tuple(0,1,0).\n"
+                          "literal_tuple(0,0).\n"
+                          "literal_tuple(0,2,0).\n"
+                          "rule(disjunction(0),normal(0),0).\n"
+                          "atom_tuple(0,1).\n"
+                          "atom_tuple(0,3,1).\n"
+                          "literal_tuple(0,1).\n"
+                          "literal_tuple(0,2,1).\n"
+                          "rule(disjunction(0),normal(0),1).\n";
+
+    REQUIRE(readText(false, true));
+    REQUIRE(out.str() == expected);
+}
+
+TEST_CASE_METHOD(Fixture, "Reify cycle", "[reify]") {
+    in << "a:-b.";
+    in << "b:-a.";
+
+    const auto expected = "atom_tuple(0).\n"
+                          "atom_tuple(0,1).\n"
+                          "literal_tuple(0).\n"
+                          "literal_tuple(0,2).\n"
+                          "rule(disjunction(0),normal(0)).\n"
+                          "atom_tuple(1).\n"
+                          "atom_tuple(1,2).\n"
+                          "literal_tuple(1).\n"
+                          "literal_tuple(1,1).\n"
+                          "rule(disjunction(1),normal(1)).\n"
+                          "scc(0,1).\n"
+                          "scc(0,2).\n";
+
+    REQUIRE(readText(true));
+    REQUIRE(out.str() == expected);
+}
+
+TEST_CASE_METHOD(Fixture, "Reify choice", "[reify]") {
+    in << "{a, b}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() ==
+            "atom_tuple(0).\natom_tuple(0,1).\natom_tuple(0,2).\nliteral_tuple(0).\nrule(choice(0),normal(0)).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify sum", "[reify]") {
+    in << ":-1 {a, b}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "atom_tuple(0).\nweighted_literal_tuple(0).\nweighted_literal_tuple(0,1,1).\nweighted_literal_"
+                         "tuple(0,2,1).\nrule(disjunction(0),sum(0,1)).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify minimize", "[reify]") {
+    in << "#minimize {a=10, b=20}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "weighted_literal_tuple(0).\nweighted_literal_tuple(0,1,10).\nweighted_literal_tuple(0,2,20)."
+                         "\nminimize(0,0).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify project", "[reify]") {
+    in << "#project {a}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "project(1).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify output", "[reify]") {
+    in << "#output a:b,c.";
+    REQUIRE(readText());
+    REQUIRE(out.str() ==
+            "outputTerm(a,0).\nliteral_tuple(0).\nliteral_tuple(0,2).\nliteral_tuple(0,3).\noutput(0,0).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify external", "[reify]") {
+    in << "#external a.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "external(1,false).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify assume", "[reify]") {
+    in << "#assume {a}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "assume(1).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify heuristic", "[reify]") {
+    in << "#heuristic a. [1, level]";
+    in << "#heuristic b : c. [2@1, true]";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "literal_tuple(0).\nheuristic(1,level,1,0,0).\nliteral_tuple(1).\nliteral_tuple(1,3)."
+                         "\nheuristic(2,true,2,1,1).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify edge", "[reify]") {
+    in << "#edge (1,2) : a.";
+    in << "#edge (2,1).";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "literal_tuple(0).\nliteral_tuple(0,1).\nedge(1,2,0).\nliteral_tuple(1).\nedge(2,1,1).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify sorted tuples", "[reify]") {
+    in << " {a; b}.";
+    in << " {b; a}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "atom_tuple(0).\natom_tuple(0,1).\natom_tuple(0,2).\nliteral_tuple(0).\nrule(choice(0),normal("
+                         "0)).\nrule(choice(0),normal(0)).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify unique tuples", "[reify]") {
+    in << " {a; b; a}.";
+    in << " {a; b}.";
+    REQUIRE(readText());
+    REQUIRE(out.str() == "atom_tuple(0).\natom_tuple(0,1).\natom_tuple(0,2).\nliteral_tuple(0).\nrule(choice(0),normal("
+                         "0)).\nrule(choice(0),normal(0)).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify theory terms", "[reify]") {
+    in << "asp 1 0 0\n";
+    in << "9 0 6 42\n";
+    in << "9 1 0 6 banana\n";
+    in << "9 2 14 4 2 12 13\n";
+    in << "0";
+    REQUIRE(readAspif());
+    REQUIRE(out.str() == "theory_number(6,42).\ntheory_string(0,\"banana\").\ntheory_tuple(0).\ntheory_tuple(0,0,12)."
+                         "\ntheory_tuple(0,1,13).\ntheory_function(14,4,0).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify theory atoms", "[reify]") {
+    in << "asp 1 0 0\n";
+    in << "9 4 0 1 10 0\n";
+    in << "9 5 6 0 1 1\n";
+    in << "9 6 6 0 1 1 2 3\n";
+    in << "0";
+    REQUIRE(readAspif());
+    REQUIRE(out.str() ==
+            "theory_tuple(0).\ntheory_tuple(0,0,10).\nliteral_tuple(0).\ntheory_element(0,0,0).\ntheory_element_tuple("
+            "0).\ntheory_element_tuple(0,1).\ntheory_atom(6,0,0).\ntheory_atom(6,0,0,2,3).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify theory unique tuples", "[reify]") {
+    in << "asp 1 0 0\n";
+    in << "9 2 14 4 2 12 13\n";
+    in << "9 2 37 9 2 12 13\n";
+    in << "0";
+    REQUIRE(readAspif());
+    REQUIRE(out.str() == "theory_tuple(0).\ntheory_tuple(0,0,12).\ntheory_tuple(0,1,13).\ntheory_function(14,4,0)."
+                         "\ntheory_function(37,9,0).\n");
+}
+
+TEST_CASE_METHOD(Fixture, "Reify theory quoting", "[reify]") {
+    in << "asp 1 0 0\n";
+    in << "9 1 0 6 hell\"o\n";
+    in << "9 1 1 6 gre\\at\n";
+    in << "9 1 2 6 worl\nd\n";
+    in << "0";
+    REQUIRE(readAspif());
+    REQUIRE(out.str() ==
+            "theory_string(0,\"hell\\\"o\").\ntheory_string(1,\"gre\\\\at\").\ntheory_string(2,\"worl\\nd\").\n");
+}
+
+} // namespace Potassco::Test::Reify


### PR DESCRIPTION
## Changes
- Moved **Reifier** headers and sources from `libreify/` into `potassco/`, `src/`, and `tests/`.
- Updated Reifier to support **libpotassco 2.0.0**.
- Cleaned up namespaces so Reifier lives under `Potassco`.
- Started adapting code to **C++20**.
- Added a command-line option to `lpconvert` to enable **reification**.
- Updated **CMakeLists**.

## Notes
- I tried my best to modernize the code, but there may be more improvements possible.
